### PR TITLE
update github-app-token version

### DIFF
--- a/.github/workflows/update-infrastructure-repo.yaml
+++ b/.github/workflows/update-infrastructure-repo.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate token for writeback to pr
         id: generate_token
         # v1.5.1
-        uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4
+        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
         with:
           app_id: 172868
           private_key: ${{ secrets.write-back-app-pem }}


### PR DESCRIPTION
The version currently in use doesn't tell you what you've done wrong if you haven't installed the github app prior to using this for example.