### PR TITLE
add optional field for service name in update-infra workflow

### DIFF
--- a/.github/workflows/update-infrastructure-repo.yaml
+++ b/.github/workflows/update-infrastructure-repo.yaml
@@ -27,6 +27,10 @@ on:
         required: false
         type: number
         default: 172868
+      service:
+        required: false
+        type: string
+        default: ""
 
     secrets:
       approve-pr-token:
@@ -75,7 +79,7 @@ jobs:
           path: ${{ inputs.working-directory }}
           token: ${{ steps.generate_token.outputs.token }}
           commit-message: Update infrastructure ${{ matrix.environment }} to ${{ github.sha }}
-          title: Update infrastructure ${{ matrix.environment }} to ${{ github.sha }}
+          title: Update infrastructure ${{ matrix.environment }} to ${{ inputs.service }}:${{ github.sha }}
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: update-${{ matrix.environment }}-to-${{ github.sha }}


### PR DESCRIPTION
Adding a new optional field called `service` to the update-infrastructure-repo shared workflow.
This string will be used in the PR title.
The reason for this is that I am experiencing issues with deploying multiple services at the same time from the same github sha.
Example: repo `my-repo` contains both services `cat-api` and `dog-api`.
When deploying the repository will deploy an image for both services. And this shared workflow should create 4 seperate PRs.
- One for updating staging for `cat-api`
- One for updating production for `cat-api`.
- One for updating staging for `dog-api`
- One for updating production for `dog-api`

This worklow will create the same two static PR titles:
`Update infrastructure staging to b3000de83f1d80d67508c7cfad808e313267f48d`
`Update infrastructure production to b3000de83f1d80d67508c7cfad808e313267f48d`

This will create a collision between the PR names of the four PRs.
I would like the option to include a service name:
`Update infrastructure staging to dog-api:b3000de83f1d80d67508c7cfad808e313267f48d`
