### PR TITLE
feat: Label deployment PRs with the `deployment` label

### DIFF
--- a/.github/workflows/update-infrastructure-repo.yaml
+++ b/.github/workflows/update-infrastructure-repo.yaml
@@ -100,7 +100,7 @@ jobs:
             ${{ github.event.head_commit.message }}
 
           labels: |
-            automated pr
+            deployment
             service:${{ inputs.service }}
             environment:${{ matrix.environment }}
 


### PR DESCRIPTION
By using a specific label to denote that a PR trigger a deployment we
can separate these PRs from others. This will make discovery of future
deployments visible.
