### PR TITLE
feat: Change close-existing-prs to be opt-out instead of opt-in

### DIFF
--- a/.github/workflows/update-infrastructure-repo.yaml
+++ b/.github/workflows/update-infrastructure-repo.yaml
@@ -34,7 +34,7 @@ on:
       close-existing-prs:
         required: false
         type: boolean
-        default: false
+        default: true
         description: If close-existing-prs is true, this workflow will look up existing open PR's for the same environment and service, and close them. This will leave you with only 1 PR per service/environment-combination.
 
     secrets:
@@ -100,7 +100,7 @@ jobs:
           branch: ${{ steps.set-branch-name.outputs.BRANCH }}
           delete-branch: true
           body: |
-            Changes from ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+            Changes from ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
 
             ${{ github.event.head_commit.message }}
 


### PR DESCRIPTION
Since we have an if-test that `service` is properly set, we should be safe to change this feature to an opt-out feature instead of opt-in. Thus, we don't require all consumers that use `@main` to make changes to get this improvement.
