### PR TITLE
chore: update token used for approval action

### DIFF
--- a/.github/workflows/update-infrastructure-repo.yaml
+++ b/.github/workflows/update-infrastructure-repo.yaml
@@ -164,7 +164,7 @@ jobs:
         if: ${{ matrix.auto-approve == 'true' }}
         uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
         with:
-          github-token: ${{ secrets.approve-pr-token }}
+          github-token: ${{ steps.generate_token.outputs.token }}
           number: ${{ steps.cpr.outputs.pull-request-number }}
           repo: ${{ inputs.source-github-repo }}
 


### PR DESCRIPTION
We are getting this error in our pipeline: 
<img width="906" height="226" alt="image" src="https://github.com/user-attachments/assets/69cdbcc1-61af-4b89-ab6f-7783c8051d05" />

Looking at the workflow, it striked me that every other step was using the output from a step for github token, so hoping that is the reason?

This pull request makes a small change to the GitHub Actions workflow for updating the infrastructure repository. The change updates the source of the GitHub token used for the pull request approval step.

* The `github-token` input for the `juliangruber/approve-pull-request-action` is now set to use the token generated in the `generate_token` step (`steps.generate_token.outputs.token`) instead of the previous `secrets.approve-pr-token`.